### PR TITLE
[Feat] 초기 화면 분기처리

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,74 @@
-import React from "react";
-import { redirect } from "next/navigation";
+"use client";
 
-//해당 페이지에서 적절하게 navgiate하는 로직 구성하기
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
 export default function HomePage() {
-  // useRouter는 훅 -> 렌더링 도중 사용 x, useEffect에서 사용할 것
-  // const router = useRouter();
-  // router.push("/login");
+  const router = useRouter();
 
-  //todo: 필요에 따라 onboarding 혹은 home들로 리다이렉트 하는 로직 필요
-  redirect("/login");
-  return <></>;
+  useEffect(() => {
+    const userStr = localStorage.getItem("user");
+
+    if (!userStr) {
+      // user 데이터가 없으면 로그인 페이지로 이동
+      router.push("/login");
+      return;
+    }
+
+    const user = JSON.parse(userStr);
+
+    if (!user || !user.refreshToken) {
+      // refreshToken이 없으면 로그인 페이지로 이동
+      router.push("/login");
+      return;
+    }
+
+    // Refresh Token으로 새 Access Token 및 Refresh Token 요청
+    refreshAccessToken(user.refreshToken).then((newTokens) => {
+      if (newTokens) {
+        // 새 Access Token 및 Refresh Token 저장
+        localStorage.setItem(
+          "user",
+          JSON.stringify({
+            ...user,
+            accessToken: newTokens.accessToken,
+            refreshToken: newTokens.refreshToken,
+          }),
+        );
+        // 새 토큰 저장 후 /home으로 리다이렉트
+        router.push("/home");
+      } else {
+        // 재발급 실패 시 로그인 페이지로 이동
+        router.push("/login");
+      }
+    });
+  }, [router]);
+
+  return <div>로그인 중...</div>; // 리다이렉트만 수행되므로 UI를 렌더링하지 않음
+}
+
+// Refresh Token으로 Access Token 및 Refresh Token 재발급 요청
+async function refreshAccessToken(refreshToken: string) {
+  try {
+    const response = await fetch(
+      `https://talkspark-dev-api.p-e.kr/api/member/refresh?refreshToken=${refreshToken}`,
+      {
+        method: "GET",
+      },
+    );
+
+    if (response.ok) {
+      const data = await response.json();
+      return {
+        accessToken: data.accessToken, // 새 Access Token
+        refreshToken: data.refreshToken, // 새 Refresh Token
+      };
+    }
+
+    console.error("Failed to refresh tokens:", response.status);
+    return null; // 재발급 실패
+  } catch (error) {
+    console.error("Error refreshing tokens:", error);
+    return null; // 네트워크 또는 기타 오류
+  }
 }


### PR DESCRIPTION
## 📄 요약
첫 페이지 접속 시 사용자 권한에 따른 분기 처리 구현했습니다.
(현재는 초기 화면 렌더링 시 /login으로 무조건 리다이렉션 이후 '로그인 버튼'의 콜백 함수에 의해 명함 생성에 대한 분기 처리)

1. 회원가입 하지 않은 사용자 (=로컬 스토리지에 user 객체가 없는 사용자)
: /login으로 라우팅 처리

2. accessToken이 만료된 사용자
: refreshToken으로 accessToken, refreshToken 재발급

3. accessToken이 유효한 사용자
: /home으로 라우팅 처리

## 🔎 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정 (아래에 issue #를 남겨주세요)
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 작업 화면 스크린샷 (선택)


## 💬 공유사항 to 리뷰어

더 좋은 방법이 있으면 반영해서 수정하도록 하겠습니다!

<!-- 이슈는 해당사항 있는 사람만 주석 해제하고 사용하시면 됩니다.
-- ## 🚨 관련 이슈 번호

      close 관련 이슈 번호
 --> close #85 

## 📌 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 관련 label을 선택했습니다.
- [x] 변경 사항에 대한 로컬 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 머지할 브랜치를 확인했습니다.

