### PR TITLE
[Fix] 방장여부 상태 저장방식 수정

### DIFF
--- a/src/app/(flow)/flow/page.tsx
+++ b/src/app/(flow)/flow/page.tsx
@@ -7,6 +7,7 @@ const BeforeSelect = dynamic(
   () => import("@/src/components/flow/BeforeSelect"),
   { ssr: false },
 );
+import { get } from "@/src/apis";
 // import AfterSelect from "@/src/components/flow/AfterSelect";
 // import BeforeSelect from "@/src/components/flow/BeforeSelect";
 import Header from "@/src/components/Headers/Header";
@@ -123,7 +124,7 @@ const Flow = () => {
   const user = getUserData();
   const router = useRouter();
 
-  const [isHost, setIsHost] = useState(!!localStorage.getItem("isGameHost")); //방장 여부
+  const [isHost, setIsHost] = useState<boolean>(false); //방장 여부
 
   const [isReady, setIsReady] = useState(false);
   const [cardStep, setCardStep] = useState(0); //소켓으로 on 해올 예정 -> todo: 아마 현재 문제가 뭔지에 대해서...
@@ -155,6 +156,17 @@ const Flow = () => {
   const socketRef = useRef<any>(null);
 
   useEffect(() => {
+    const fetchHostStatus = async () => {
+      try {
+        const response = await get(`/api/rooms/is-host?roomId=${roomId}`);
+        setIsHost(response.data as boolean);
+      } catch (error) {
+        console.error("Error fetching host status:", error);
+      }
+    };
+
+    fetchHostStatus();
+
     //여기서 다시 연결
     console.log("연결 중!");
     socketRef.current = io("https://talkspark.site/", {

--- a/src/app/creating-room/result/page.tsx
+++ b/src/app/creating-room/result/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import Button from "@/src/components/common/Button";
 import kakaoImage from "@/public/Image/onBoarding/kakaoImage.svg";
-import Image from "next/image";
+import Button from "@/src/components/common/Button";
 import QrCode from "@/src/components/QrCode/QrCode";
+import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect } from "react";
 
 const Result = () => {
   const router = useRouter();
@@ -60,9 +60,9 @@ const Result = () => {
   };
 
   const handleHostStartGame = () => {
-    if (typeof window !== "undefined") {
-      localStorage.setItem("isGameHost", "true");
-    }
+    // if (typeof window !== "undefined") {
+    //   localStorage.setItem("isGameHost", "true");
+    // }
     router.push(`/team/${roomId}`);
   };
 

--- a/src/app/team/[id]/page.tsx
+++ b/src/app/team/[id]/page.tsx
@@ -41,7 +41,7 @@ const TeamDetail = () => {
   const router = useRouter();
 
   const [user, setUser] = useState<UserLocalData | null>(null);
-  const [isHost, setIsHost] = useState(!!localStorage.getItem("isGameHost"));
+  const [isHost, setIsHost] = useState<boolean | null>(null);
   const { id } = useParams(); // roomId 파라미터 가져온 후 get
   const [teamData, setTeamData] = useState<GameRoomDetail | null>(null);
   const [userDatas, setUserDatas] = useState<Participant[] | null>(null);
@@ -114,9 +114,10 @@ const TeamDetail = () => {
 
       const setHostAndRoomData = async () => {
         try {
-          //const response = await get(`/api/rooms/is-host?roomId=${id}`); //host 여부 받아오는 api
-          const response2 = await get(`/api/rooms/${id}`); //방에 대한 정보 받아오는 api
-          //setIsHost(response.data as boolean);
+          const response = await get(`/api/rooms/is-host?roomId=${id}`); // 방장 여부 확인 API
+          setIsHost(response.data as boolean);
+
+          const response2 = await get(`/api/rooms/${id}`); // 방 정보 가져오는 API
           setTeamData(response2.data as GameRoomDetail);
           console.log(response2.data);
         } catch (err) {
@@ -126,7 +127,16 @@ const TeamDetail = () => {
 
       setHostAndRoomData();
 
-      // window.addEventListener("beforeunload", handleBeforeUnload);
+      const handleBeforeUnload = () => {
+        socketRef.current.emit("leaveRoom", {
+          roomId: id,
+          accessToken: user.accessToken,
+          isHost,
+        });
+        socketRef.current.disconnect();
+      };
+
+      window.addEventListener("beforeunload", handleBeforeUnload);
 
       return () => {
         if (socketRef.current) {
@@ -141,7 +151,7 @@ const TeamDetail = () => {
             });
           }
           socketRef.current.disconnect();
-          // window.removeEventListener("beforeunload", handleBeforeUnload);
+          window.removeEventListener("beforeunload", handleBeforeUnload);
         }
       };
     }


### PR DESCRIPTION
## 📄 요약
- 방장여부를 판단할 때 사용되는 isHost 데이터를 저장하는 방식을 수정했습니다.
    - 이전 방식: 방 생성 이후 게임 시작 시 **로컬 스토리지에** 값 저장 → 다른 방 입장 시 방장으로 판단하는 문제 발생
    - 변경 방식: 서버에 호스트 여부를 판단하는 api 요청 → 해당 값을 로컬 상태로 저장 이후 하위 컴포넌트에서 사용

## 🔎 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정 (아래에 issue #를 남겨주세요)
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 관련 label을 선택했습니다.
- [x] 변경 사항에 대한 로컬 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 머지할 브랜치를 확인했습니다.

